### PR TITLE
Remove zshuery as it's deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ These frameworks make customizing your zsh setup easier.
 * [zgen](https://github.com/tarjoilija/zgen) - A lightweight plugin manager for ZSH inspired by antigen.
 * [zilsh](https://github.com/zilsh/zilsh) - A zsh config system that aims to appeal more to power-users and follow the simplistic approach of vim-pathogen. 
 * [zoppo](https://github.com/zoppo/zoppo) - the crippled configuration framework for Zsh. As an italian saying goes: "chi va con lo zoppo, impara a zoppicare", we realized we were walking with a cripple and are now going to become crippled ourselves.
-* [zshuery](https://github.com/myfreeweb/zshuery) - A simpler zsh configuration framework. jQuery did this for JS, we're doing it for zsh. 
 * [ztanesh](https://github.com/miohtama/ztanesh) - Improve your UNIX command line experience and productivity with the the configuration provided by ztanesh project: the tools will make your shell more powerful and easier to use.
 
 Not a framework, but still useful


### PR DESCRIPTION
I could also add the line back but with a deprecated note:
```
* [zshuery](https://github.com/myfreeweb/zshuery) - [DEPRECATED] A simpler zsh configuration framework. jQuery did this for JS, we're doing it for zsh. 
```