### PR TITLE
Added iterm-tab-colors to Plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ These frameworks make customizing your zsh setup easier.
 * [host-switch](https://github.com/LockonS/host-switch) - Make it easier to switch in different `/etc/hosts` files during development
 * [hub-ci-zsh-plugin](https://github.com/raymondjcox/hub-ci-zsh-plugin) - A simple plugin for adding hub ci-status to your zsh theme.
 * [iosctl](https://github.com/obayer/iosctl) - quickly access App, Data, and Log of the running simulator.
+* [iterm-tab-colors](https://github.com/tysonwolker/iterm-tab-colors) - Automatically changes iTerm tab color based on the current working directory 
 * [java-zsh-plugin](https://github.com/Xetius/java-zsh-plugin) - Adds a setjdk command so you can switch easily between different versions of the jdk
 * [jhipster-oh-my-zsh-plugin](https://github.com/jhipster/jhipster-oh-my-zsh-plugin) - Adds commands for [jHipster](http://jhipster.github.io/)
 * [jvm](https://github.com/mgryszko/jvm) - Allows selection of JDK on OS X.


### PR DESCRIPTION
The aim of this plugin is to set a random but consistent tab color on iTerm tabs based on the directory you are in. If you have more than one tab in the same working directory they will have the same color and will remain the same every terminal session.
