### PR TITLE
Add zsh-interactive-cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ These frameworks make customizing your zsh setup easier.
 * [zsh-hints](https://github.com/joepvd/zsh-hints) - Display glob and parameter flags and other non completable info right under your editing buffer.
 * [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) - Needs to be loaded after zsh-syntax-highlighting, or they'll both break. You'll also need to bind keys to its functions, details are in the README.md
 * [zsh-history](https://github.com/b4b4r07/zsh-history) - Extend history so that it can be queried by SQL
+* [zsh-interactive-cd](https://github.com/changyuheng/zsh-interactive-cd) - Fish like interactive tab completion for `cd`.
 * [zsh-konsole-theme-changer](https://github.com/rocknrollMarc/zsh-konsole-theme-changer) - Toggle konsole theme from zsh.
 * [zsh-kubernetes](https://github.com/Dbz/zsh-kubernetes) - Add kubernetes helper functions and aliases
 * [zsh-manydots-magic](https://github.com/knu/zsh-manydots-magic) - A zle tweak for emulating `...'==`../..' etc.


### PR DESCRIPTION
`zsh-interactive-cd` is a fish like interactive tab completion plugin for `cd`.