### PR TITLE
Changed README.md to link to correct prezto plugin repository. Previo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ These frameworks make customizing your zsh setup easier.
 
 **oh-my-zsh** is a community-driven framework for managing your zsh configuration. Includes 120+ optional plugins (rails, git, OSX, hub, capistrano, brew, ant, macports, etc), over 120 themes to spice up your morning, and an auto-update tool that makes it easy to keep up with the latest updates from the community.
 
-### [prezto](https://github.com/zsh-users/prezto)
+### [prezto](https://github.com/sorin-ionescu/prezto)
 
 **Prezto** enriches the ZSH command line interface environment with sane defaults, aliases, functions, auto completion, and prompt themes.
 
@@ -722,7 +722,7 @@ Most of these plugins can be installed by adding `antigen bundle githubuser/repo
 2. `git clone repo`
 3. Add the repo to your plugin list
 
-### [Prezto](https://github.com/zsh-users/prezto)
+### [Prezto](https://github.com/sorin-ionescu/prezto)
 
 1. Clone the plugin into your prezto modules directory
 2. Add the plugin to your `.zpreztorc` file


### PR DESCRIPTION
…usly zsh-users/prezto however it should be sorin-ionescu/prezto as stated by zsh-users/prezto repository redirect.

https://github.com/zsh-users/prezto is redirected to https://github.com/prezto-inactive-community-fork/prezto and states to use https://github.com/sorin-ionescu/prezto -- the original fork.

Changed README.md to reflect the correct repository for prezto plugin

- [ ] A plugin, theme or completion
- [ x] A link to an external resource like a blog post

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->
- [x ] I have confirmed that the link(s) in my PR are good
- [x ] My entries are single lines and are in the appropriate (plugins, themes, completions) section
- [ x] I have read the **CONTRIBUTING** document.
- [ x] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unixorn/awesome-zsh-plugins/252)
<!-- Reviewable:end -->
