### PR TITLE
Add steef theme as a standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ If you're using [Antigen](https://github.com/zsh-users/antigen), you can test th
 * [spowerline](https://mbauhardt.github.io/spowerline/) - Written in scala, inspired by agnoster, tmux powerline, vim powerline and the vim status plugin.
 * [staples](https://github.com/dersam/staples) - based on bureau, displays user@host if connected through SSH.
 * [statusline](https://github.com/el1t/statusline) - A responsive zsh theme that provides informational segments when you need them.
+* [steef](https://github.com/danihodovic/steeef) - Zsh steeef theme as a standalone repository. The purpose behind this repo is avoid having a dependency on oh-my-zsh when using the steeef theme. Zsh plugin managers such as Antibody can use the theme without having to use oh-my-zsh.
 * [sugarfree](https://github.com/cbrock/sugar-free) - Based on the [Pure](https://github.com/sindresorhus/pure) and [Candy](https://github.com/BinaryMuse/oh-my-zsh/blob/binarymuse/themes/candy.zsh-theme) themes.
 * [tahuri](https://github.com/Tahuri/oh-my-zshel-theme-tahuri) - Zsh theme for Arch Linux.
 * [the-time-lord](https://github.com/jhwhite/the-time-lord) - A theme based on gallifrey.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Zsh steeef theme as a standalone repository. The purpose behind this repo is avoid having a dependency on oh-my-zsh when using the steeef theme. Zsh plugin managers such as Antibody can use the theme without having to use oh-my-zsh.

## Types of changes
<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->
- [x] A plugin, theme or completion
- [ ] A link to an external resource like a blog post

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->
- [x] I have confirmed that the link(s) in my PR are good
- [x] My entries are single lines and are in the appropriate (plugins, themes, completions) section
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
