### PR TITLE
carcassoid has gone 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,6 @@ If you're using [Antigen](https://github.com/zsh-users/antigen), you can test th
 * [bureau-colorized](https://github.com/edwild22/bureau-colorized) - Based on bureau.zsh-theme, for people who use Git and NVM.
 * [bureau](https://github.com/isqua/bureau) - A clear and informative two-lined prompt. Includes git status optimized for large repositories.
 * [candy-light](https://github.com/RanaExMachina/oh-my-zsh-candy-light) - Light version of the candy theme.
-* [carcassoid](https://github.com/denmord/carcassoid-zsh-theme) - Easily customizable zsh theme.
 * [charged](https://github.com/robwierzbowski/charged-zsh-theme) - A zsh prompt optimized for the solarized dark terminal theme.
 * [chi](https://github.com/andela-abankole/chi) - A zsh theme optimized for iTerm users on OS X.
 * [ciacho](https://github.com/Ciacho/ciacho-ohmyzsh-theme) - Based on Agnoster


### PR DESCRIPTION
## Description
Removed carcassoid theme since it has gone 404.

## Types of changes
- [x] A plugin, theme or completion
- [ ] A link to an external resource like a blog post

## Checklist:
- [x] I have confirmed that the link(s) in my PR are good
- [ ] My entries are single lines and are in the appropriate (plugins, themes, completions) section
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
