### PR TITLE
Adding `zsh-docker-run` to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ These frameworks make customizing your zsh setup easier.
 * [docker-compose](https://github.com/sroze/docker-compose-zsh-plugin) Show docker container status in your prompt.
 * [docker-fun](https://github.com/johnlabarge/docker_fun) - Adds docker convenience functions.
 * [docker-helpers](https://github.com/unixorn/docker-helpers.zshplugin) - A collection of docker helper scripts.
+* [docker-run](https://github.com/rawkode/zsh-docker-run) - Go back to running your commands "naturally", we'll handle the container.
 * [dropbox](https://github.com/horosgrisa/zsh-dropbox) - A dropbox plugin for Zsh that provides `dropbox-cli` and `dropbox-uploader` commands.
 * [elixir-oh-my-zsh](https://github.com/gusaiani/elixir-oh-my-zsh) - Adds shortcuts for Elixir, IEX, Mix and Phoenix.
 * [emoji-cli](https://github.com/b4b4r07/emoji-cli) - :scream: Emoji completion on the command line.


### PR DESCRIPTION
## Description
`zsh-docker-run` allows users to go back to the simpler times of runnning `php -r 'echo "Hello";'` and `npm install`, even while running said commands in containers.

This plugin will also detect if your command should be run in a `docker-compose` environment, by inspecting the local directory.

## Types of changes
- [x] A plugin, theme or completion
- [ ] A link to an external resource like a blog post

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->
- [x] I have confirmed that the link(s) in my PR are good
- [x] My entries are single lines and are in the appropriate (plugins, themes, completions) section
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
