### PR TITLE
Disable markdownlint's ordered list item prefix style check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,6 +20,8 @@ engines:
         enabled: false
       MD026:
         enabled: false
+      MD029:
+        enabled: false
       MD033:
         enabled: false
   shellcheck:


### PR DESCRIPTION
# Description

Disable markdownlint's ordered list item prefix style check

# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a completion
- [ ] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Checklist:

- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes, completions) section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
