### PR TITLE
Add zsh-colored-man-pages plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ These frameworks make customizing your zsh setup easier.
 * [cdr](https://github.com/willghatch/zsh-cdr) - Easy setup of cdr for zsh.
 * [clean-project](https://github.com/wwilsman/zsh-clean-project) - Remove files from projects (automatically by default). Useful for keeping `.DS_Store` and `Thumbs.db` files from cluttering your directories.
 * [cmd-architect](https://github.com/psprint/zsh-cmd-architect) - Build commands from what's in history and at prompt, move, delete, add command segments and search history with multi-word queries.
+* [colored-man-pages](https://github.com/ael-code/zsh-colored-man-pages) - Colorize man pages
 * [colored-man-pages-mod](https://github.com/zuxfoucault/colored-man-pages_mod) - Forked from [robbyrussell/oh-my-zsh/plugins/colored-man-pages](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/colored-man-pages/colored-man-pages.plugin.zsh). Colorizes `man` output.
 * [colors](https://github.com/Tarrasch/zsh-colors) - Makes it easier to colorize text from the CLI. `red foo` just works.
 * [command-not-found](https://github.com/Tarrasch/zsh-command-not-found) - mirror of the oh-my-zsh command-not-found plugin so you don't have to include all of omz.

--- a/README.md
+++ b/README.md
@@ -580,7 +580,6 @@ If you're using [Antigen](https://github.com/zsh-users/antigen), you can test th
 * [bttf-color-zsh](https://github.com/yasuhiroki/bttf-color-zsh) - BTTF color theme.
 * [bullet-train](https://github.com/caiogondim/bullet-train-oh-my-zsh-theme) - Inspired by the Powerline Vim plugin. It aims for simplicity, showing information only when it's relevant.
 * [bunnyruni](https://github.com/jopcode/oh-my-zsh-bunnyruni-theme) - Simple, clean, and beautiful theme.
-* [bureau-colorized](https://github.com/edwild22/bureau-colorized) - Based on bureau.zsh-theme, for people who use Git and NVM.
 * [bureau](https://github.com/isqua/bureau) - A clear and informative two-lined prompt. Includes git status optimized for large repositories.
 * [candy-light](https://github.com/RanaExMachina/oh-my-zsh-candy-light) - Light version of the candy theme.
 * [charged](https://github.com/robwierzbowski/charged-zsh-theme) - A ZSH prompt optimized for the solarized dark terminal theme.


### PR DESCRIPTION
Add [zsh-colored-man-pages](https://github.com/ael-code/zsh-colored-man-pages)

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

<!--- Describe your changes in detail -->

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a completion
- [x] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes, completions) section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I have stripped leading **zsh-** or **oh-my-zsh-** from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the o and z sections of the list.
