### PR TITLE
Add sys-diver-zsh plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ These frameworks make customizing your zsh setup easier.
 * [symfony.plugin.zsh](https://github.com/voronkovich/symfony.plugin.zsh) - ZSH plugin for Symfony 2 and 3.
 * [syntax-highlighting-filetypes](https://github.com/trapd00r/zsh-syntax-highlighting-filetypes) - ZSH syntax highlighting with dircolors in realtime.
 * [syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) - Add syntax highlighting to your ZSH. Make sure you load this _before_ zsh-users/zsh-history-substring-search or they will both break.
+* [sys-diver-zsh](https://github.com/ToruIwashita/sys-diver-zsh) - A zsh plugin for directory change or editor startup with only key operations using widgits without typing command.
 * [sysadmin-util](https://github.com/skx/sysadmin-util) - Steve Kemp's collection of tool scripts for sysadmins.
 * [t32](https://github.com/chrissicool/zsh-t32) - Plugin for the Lauterbach Trace32 toolset. It automatically registers fonts and sets all necessary environment variables to run the t32 toolset.
 * [terminal-app](https://github.com/the8/zsh-terminal-app) - A plugin for integrating with the new El Capitan Terminal.app features.


### PR DESCRIPTION
Would you merge this?

# Description

Add [sys-diver-zsh](https://github.com/ToruIwashita/sys-diver-zsh) plugin. 

# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a completion
- [x] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes, completions) section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I have stripped leading **zsh-** or **oh-my-zsh-** from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the o and z sections of the list.
