### PR TITLE
Update Zplugin description (add Turbo Mode link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ These frameworks make customizing your zsh setup easier.
 
 ### [zplugin](https://github.com/zdharma/zplugin)
 
-**Zplugin** is a next-era plugin manager with [semigraphical UI](https://github.com/zdharma/zplugin-crasis).
+**Zplugin** is a next-era plugin manager with [semigraphical UI](https://github.com/zdharma/zplugin-crasis) and a [Turbo Mode](https://github.com/zdharma/zplugin#turbo-mode).
 
 ### [ZPM](https://github.com/horosgrisa/ZPM)
 


### PR DESCRIPTION
# Description

Added one important link, to description of Turbo Mode, on Zplugin's github page.

# Type of changes

- [x] A link to an external resource like a blog post
- [ ] Add/remove a completion
- [ ] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes, completions) section.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
- [ ] I have stripped leading **zsh-** or **oh-my-zsh-** from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the o and z sections of the list.
