### PR TITLE
ZSH kube-ps1 prompt helper for kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ These frameworks make customizing your zsh setup easier.
 * [kill-node](https://github.com/vmattos/kill-node) - zsh plugin for murdering node process families.
 * [kitsunebook.plugin.zsh](https://github.com/d12frosted/kitsunebook.plugin.zsh) - KitsuneBook plugin for oh-my-zsh.
 * [konsole-theme-changer](https://github.com/rocknrollMarc/zsh-konsole-theme-changer) - Toggle konsole theme from ZSH.
+* [kube-ps1](https://github.com/jonmosco/kube-ps1) - ZSH plugin for kubectl that adds current context and namespace.
 * [kubectl-zsh-plugin](https://github.com/mattbangert/kubectl-zsh-plugin) - ZSH plugin for managing kubectl.
 * [kubernetes](https://github.com/Dbz/zsh-kubernetes) - Add kubernetes helper functions and aliases.
 * [laravel](https://github.com/crazybooot/laravel-zsh-plugin) - Add shortcuts for Laravel 5, 5.1, 5.2 & 5.3.


### PR DESCRIPTION
# Description

A script that lets you add the current Kubernetes context and namespace configured on kubectl to your Zsh prompt strings 

# Type of changes
- [ ] A link to an external resource like a blog post
- [ ] Add/remove a completion
- [x ] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Checklist:

- [x ] I have confirmed that the link(s) in my PR are valid.
- [x ] My entries are single lines and are in the appropriate (plugins, themes, completions) section.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
- [x ] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the o and z sections of the list.
