### PR TITLE
Re-run doctoc to fix TOC link 'Completions' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A collection of ZSH frameworks, plugins, tutorials & themes inspired by the vari
   - [Prezto](#prezto)
   - [Zgen](#zgen)
 - [Plugins](#plugins)
-- [Even more completions](#even-more-completions)
+- [Completions](#completions)
 - [Themes](#themes)
   - [Fonts](#fonts)
 - [Installation](#installation)


### PR DESCRIPTION
# Description

Re-run doctoc to fix TOC link 'Completions' in README

# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [ ] Add/remove a plugin
- [ ] Add/remove a theme
- [x] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
