### PR TITLE
Add appspec tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ These plugins add tab completions without adding extra functions or aliases.
 * [_url-httplink](https://github.com/Valodim/zsh-_url-httplink) - Extends ZSH's \_urls completion, allowing it to complete urls from html pages.
 * [ansible-server](https://github.com/viasite-ansible/zsh-ansible-server) - Completions for viasite-ansible/ansible-server.
 * [antibody-completion](https://github.com/sinetoami/antibody-completion) - This plugin provides completion for [Antibody](https://github.com/getantibody/antibody) plugin manager.
+* [appspec](https://github.com/perlpunk/App-AppSpec-p5) - Generating completions for Bash and ZSH from YAML specs
 * [autopkg-zsh-completion](https://github.com/fuzzylogiq/autopkg-zsh-completion) - Completions for autopkg.
 * [aws_manager_plugin](https://github.com/EslamElHusseiny/aws_manager_plugin) - Add completions for the aws_manager CLI.
 * [bazel](https://github.com/jackwish/bazel) - A copy of the zsh completion script from the official [bazel](https://raw.githubusercontent.com/bazelbuild/bazel/64d9a4d6dcd720a3b7a60ff550a17a7707dd41d0/scripts/zsh_completion/_bazel) repo.


### PR DESCRIPTION
https://github.com/perlpunk/App-AppSpec-p5

It can autogenerate Bash and ZSH completions from a specification
file in App::Spec YAML format.

Followup to our discussion in https://github.com/perlpunk/MooseX-App-Plugin-ZshCompletion/issues/3

Installation and Usage instructions were added, and I added a standalone version that can be used without installing perl modules.