### PR TITLE
Add evil-registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ the state of the Zsh session and to delete the plugins and snippets from the dis
 * [enhancd](https://github.com/b4b4r07/enhancd) - A simple tool that provides enhanced `cd` command.
 * [escape-backtick](https://github.com/bezhermoso/zsh-escape-backtick) - Quickly insert escaped backticks when double-tapping "`".
 * [evalcache](https://github.com/mroth/evalcache) - Cache the output of a binary initialization command, to help lower shell startup time.
+* [evil-registers](https://github.com/zsh-vi-more/evil-registers) - Extends ZLE vi commands to remotely access named registers of the vim and nvim editors, and system selection and clipboard.
 * [exa](https://github.com/DarrinTisdale/zsh-aliases-exa) - Enables a number of aliases extending [exa](https://the.exa.website), the modern replacement for `ls`.
 * [exercism](https://github.com/fabiokiatkowski/exercism.plugin.zsh) - A plugin for [exercism.io](http://exercism.io/).
 * [expand-ealias](https://github.com/zigius/expand-ealias.plugin.zsh) - Expand specific aliases with space.


### PR DESCRIPTION
Similar to system-clipboard, but also allows access to vim and nvim registers.
Yes, it's mine. I waited until now because I don't think I'm changing its API anymore.

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

[Evil-registers](https://github.com/zsh-vi-more/evil-registers) is similar to a plugin already on the list, system-clipboard. However, this plugin brings in a few features:

- **Extensible**: by setting an element of an array to a snippet, the snippet will be run with the text that was yanked.
- **Supports remote access to editors**: Currently only vim with `+clientserver` support and nvim with [nvr](https://github.com/mhinz/neovim-remote) is supported. `"ap` will read from the `a` register from the respective editor, if it is running.

This is my plugin, so I understand skepticism. However, I have been using it comfortably for months and I want other people to find it.

# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [x] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] N/A ~~All new and existing tests passed.~~
- [x] N/A ~~Any added completions have a license file in their repository.~~
- [x] Any added plugins have a license file in their repository.
- [x] N/A ~~Any added themes have a screen shot and a license file in their repository.~~
- [x] N/A ~~I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.~~
