### PR TITLE
Add advise about fpath to Writing_Plugins.md

### DIFF
--- a/Writing_Plugins.md
+++ b/Writing_Plugins.md
@@ -12,6 +12,8 @@ Try and keep your plugins as cross-framework compatible as possible. Here are so
 
 5. If you’re making a theme, please include a screenshot so prospective users can see what it looks like without having to install it.
 
+6. If your plugin adds any of its subdirectories to the `fpath`, make sure those subdirectories only contain function definition files. This allows for frameworks to correctly [zcompile all functions](http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions). Don't make your plugin add its root directory to the `fpath`.
+
 6. Don't forget to add a license. [choosealicense.com](https://choosealicense.com) is a good tool to help you pick one.
 
 7. Submit a PR here so your plugin is easy to find :-)


### PR DESCRIPTION
# Description

All files in the fpath directories should be able to be compiled. See http://zsh.sourceforge.net/Doc/Release/User-Contributions.html#Recompiling-Functions

This allows ZSH to take advantage of compiled function digest files. See http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions


# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [ ] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] Any added completions have a license file in their repository.
- [x] Any added plugins have a license file in their repository.
- [x] Any added themes have a screen shot and a license file in their repository.
- [x] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
