### PR TITLE
Add p9k-theme-pastel, remove nonotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,6 @@ The project is very active – currently > 2000 commits.
 * [nodenv (jsahlen)](https://github.com/jsahlen/nodenv.plugin.zsh) - Auto-load `nodenv` and its completions into the shell.
 * [nodenv (mattberther)](mattberther/zsh-nodenv) - Installs, updates and loads `nodenv`. Inspired by zsh-rbenv.
 * [nohup](https://github.com/micrenda/zsh-nohup) - Add `nohup` to the current command pressing `Ctrl-H`.
-* [nonotes](https://github.com/stevemcilwain/nonotes) - Plugin for pen-testing. No more notes needed, no more copy and paste of commands.
 * [noreallyjustfuckingstopalready](https://github.com/eventi/noreallyjustfuckingstopalready) - macOS users know the pain of trying to figure out what command actually flushes the DNS cache on their version of macOS, and this plugin makes that annoyance go away.
 * [notes (aperezdc)](https://github.com/aperezdc/zsh-notes) - Inspired by [terminal_velocity](https://www.seanh.cc/terminal_velocity/), it provides a fast interface to create and access a set of [Markdown](https://en.wikipedia.org/wiki/Markdown) text files inside a directory.
 * [notes (chipsenkbeil)](https://github.com/chipsenkbeil/zsh-notes) - Provides a quick notes editing experience in ZSH.

--- a/README.md
+++ b/README.md
@@ -1224,6 +1224,7 @@ If you're using [Antigen](https://github.com/zsh-users/antigen), you can test th
 * [owiewestside](https://github.com/owenstranathan/owiewestside.zsh-theme) - Includes `git` status and virtualenv information.
 * [oxide](https://github.com/dikiaap/dotfiles/blob/master/.oh-my-zsh/themes/oxide.zsh-theme) - A Minimalistic and Dark ZSH theme.
 * [ozono](https://github.com/sfabrizio/ozono-zsh-theme) 🌏 OZ0NO - Let's Breathe a clean ZSH.
+* [p9k-theme-pastel](https://github.com/iboyperson/p9k-theme-pastel) - A theme for the [powerlevel10k](https://github.com/romkatv/powerlevel10k) prompt that puts an emphasis on simplcity while still getting important information across.
 * [pad](https://github.com/eproxus/pad.zsh-theme) - A concise and colorful oh-my-zsh theme.
 * [page](https://github.com/SLIB53/page-zsh-theme) - A simple theme with VCS support. The prompt shows 1 level of the current working directory, branch, and a color coded curved fat arrow.
 * [palenight (jenssegers)](https://github.com/jenssegers/palenight.zsh-theme) - Allows display of host information, includes `git` branch decoration.


### PR DESCRIPTION
# Description

* Add p9k-theme-pastel now that https://github.com/iboyperson/p9k-theme-pastel/issues/1 is closed.
* Removing nonotes - it is 404.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [ ] Add/remove a plugin
- [x] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. 

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [x] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
