### PR TITLE
Add zoxide under Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ The project is very active – currently > 2000 commits.
 * [zinit-console](https://github.com/zinit-zsh/zinit-console) – a semigraphical (curses) consolette for [zinit](#zinit) plugin manager.
 * [zjump](https://github.com/qoomon/zjump) - Simplify ZSH directory navigation; jump to already visited, parent or sub folders.
 * [zlong_alert](https://github.com/kevinywlui/zlong_alert.zsh) - Uses notify-send and ring a bell to alert you when a command that has taken a long time (default: 15 seconds) has completed.
+* [zoxide](https://github.com/ajeetdsouza/zoxide) - A fast alternative to `cd` that learns your habits.
 * [zredis](https://github.com/zdharma/zredis) - Adds Redis database support, with `database_key` <-> `shell_variable` binding. Supports all data types.
 * [zsh-z](https://github.com/agkozak/zsh-z) - Jump quickly to directories that you have visited "frecently." A native ZSH port of `z.sh` - without `awk`, `sed`, `sort`, or `date`.
 * [zshmarks](https://github.com/jocelynmallon/zshmarks) - A port of Bashmarks (by Todd Werth), a simple command line bookmarking plugin, for oh-my-zsh.


### PR DESCRIPTION
- Add [`zoxide`](https://github.com/ajeetdsouza/zoxide) under Plugins

# Description

`zoxide` is a ZSH plugin that tracks your directory usage, allowing you to quickly `cd` to anywhere on your filesystem using just part of the directory name as a query.

# Type of changes

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [x] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [x] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [x] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
