### PR TITLE
Remove ruby-switch that has gone 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,6 @@ The project is very active – currently > 2000 commits.
 * [ripz](https://github.com/jedahan/ripz) - Reminds you of your aliases, so you use them more. Depends on [ripgrep](https://github.com/BurntSushi/ripgrep).
 * [robo-zsh-plugin](https://github.com/shengyou/robo-zsh-plugin) - A ZSH plugin for [Robo](https://robo.li/).
 * [rockz](https://github.com/aperezdc/rockz) - Lua + LuaRocks virtual environment manager based upon VirtualZ.
-* [ruby-switch](https://github.com/LockonS/ruby-switch) - Switch ruby versions and manage the PATH variable at the same time.
 * [rvm](https://github.com/johnhamelink/rvm-zsh) - Initiates RVM and adds rubygem binaries (like compass) accessible in the user's `$PATH`.
 * [safe-kubectl](https://github.com/benjefferies/safe-kubectl) - Add some safety when running `kubectl` by warning what context you're in after a definable number of seconds since the last `kubectl` command.
 * [safe-paste](https://github.com/oz/safe-paste) - A safe-paste plugin. See Conrad Irwin's [bracketed-paste](https://cirw.in/blog/bracketed-paste) blog post.


### PR DESCRIPTION
# Description

ruby-switch is 404, remove.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [x] Add/remove a plugin
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. 

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [ ] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
