### PR TITLE
Add framework option to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,9 @@
 <!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->
 
 - [ ] A link to an external resource like a blog post
-- [ ] Add/remove a tab completion
+- [ ] Add/remove a framework
 - [ ] Add/remove a plugin
+- [ ] Add/remove a tab completion
 - [ ] Add/remove a theme
 - [ ] Text cleanups/typo fixes
 
@@ -22,7 +23,7 @@
 # Checklist:
 
 <!---
-Go over all the following points, and put an `x` in all the boxes that apply. 
+Go over all the following points, and put an `x` in all the boxes that apply.
 
 You only need to check the box for completions/plugins/themes if you added something in those categories
 -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

Update the PR template to add an option for frameworks

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove a tab completion
- [ ] Add/remove a plugin
- [ ] Add/remove a theme
- [x] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply. 

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
