### PR TITLE
Add Oh-My-Zsh! A Work of CLI Magic to the list os tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ This section is for full setup dropins - they aren't frameworks, but they're not
 
 ### Oh-My-Zsh
 
+* [Oh-My-Zsh! A Work of CLI Magic](https://medium.com/wearetheledger/oh-my-zsh-made-for-cli-lovers-installation-guide-3131ca5491fb) - Michiel Mulders installation guide for Ubuntu
 * [ZSH Gem 24](https://www.refining-linux.org/archives/59-ZSH-Gem-24-ZSH-frameworks.html) - Part of the 2011 ZSH Advent Calendar. Covers oh-my-zsh and zshuery.
 
 ### Prezto


### PR DESCRIPTION
# Description
Add the Michiel Mulders tutorial on how installing Oh-My-Zsh! on Ubuntu. Since this is one of the most viewed tutorials, I think will be useful to new users.

# Type of changes
- [x] A link to an external resource like a blog post
- [ ] Add/remove a framework
- [ ] Add/remove a plugin
- [ ] Add/remove a tab completion
- [ ] Add/remove a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment
- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-** or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name since there aren't big clusters in the **O** and **Z** sections of the list.
