### PR TITLE
Remove unreachable zdharma.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,21 +232,21 @@ A lightweight plugin manager for ZSH based on zgen. It is a superset of the bril
 
 **Zinit** is an innovative and probably (because of the Turbo) the [fastest](https://github.com/zdharma/pm-perf-test) plugin manager with support for:
 
-- [Turbo mode](http://zdharma.org/zinit/wiki/INTRODUCTION/#turbo_mode_zsh_62_53) – 80% faster Zsh startup! for example: instead of 200 ms, it'll be 40 ms,
+- Turbo mode – 80% faster Zsh startup! for example: instead of 200 ms, it'll be 40 ms,
 - completion management (selectively disable and enable completions),
 - snippets (↔ regular files downloaded via-URL, e.g.: scripts) and through them Oh My Zsh and Prezto plugins support (→ low overhead),
-- annexes (↔ Zinit [extensions](https://github.com/zinit-zsh)),
+- annexes (↔ Zinit extensions),
 - reports (from the plugin loads – plugins are no longer black boxes),
 - plugin unloading (allows e.g.: dynamic theme switching),
-- `bindkey` [capturing and remapping](https://zdharma.org/zinit/wiki/Bindkeys/#using_the_upar_etc_shorthands),
+- `bindkey` capturing and remapping,
 - [packages](https://github.com/Zsh-Packages),
-- clean fpath (the array `$fpath` is not being used to add completions and autoload functions, hence it stays concise, not bloated),
+- clean `fpath` (the array `$fpath` is not being used to add completions and autoload functions, hence it stays concise, not bloated),
 - [services](https://github.com/zservices) ↔ a single-instance, background plugins,
-- also, in general: all the mechanisms from the [Zsh Plugin Standard](http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html) – Zinit is a reference implementation of the standard.
+- also, in general: all the mechanisms from the Zsh Plugin Standard – Zinit is a reference implementation of the standard.
 
 Bonus: you can use [zinit-console](https://github.com/zinit-zsh/zinit-console) to view and change the state of the ZSH session (e.g.: list and unload plugins) and to delete the plugins and snippets from the disk.
 
-The project is very active – currently > 3000 commits.
+The project is very active – currently > 3100 commits.
 
 ### [zit](https://github.com/thiagokokada/zit)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

Remove unreachable zdharma.org links that are causing awesomebot checks to fail. Will restore them after https://github.com/zdharma/zinit/issues/489 is closed.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove/update a link to a framework
- [ ] Add/remove/update a link to a plugin
- [ ] Add/remove/update a link to a tab completion
- [ ] Add/remove/update a link to a theme
- [x] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply.

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added frameworks have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-**, **zsh-plugin** and/or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name by preventing big clusters in the **O** and **Z** sections of the list.
