### PR TITLE
Require readmes in new entries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,8 +32,8 @@ You only need to check the box for completions/plugins/themes if you added somet
 - [ ] I have confirmed that the link(s) in my PR are valid.
 - [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
 - [ ] All new and existing tests passed.
-- [ ] Any added completions have a license file in their repository.
-- [ ] Any added frameworks have a license file in their repository.
-- [ ] Any added plugins have a license file in their repository.
-- [ ] Any added themes have a screen shot and a license file in their repository.
+- [ ] Any added completions have a readme and a license file in their repository.
+- [ ] Any added frameworks have a readme and a license file in their repository.
+- [ ] Any added plugins have a readme and a license file in their repository.
+- [ ] Any added themes have a screen shot, a readme and a license file in their repository.
 - [ ] I have stripped leading and trailing **zsh-**, **zsh-plugin** and/or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name by preventing big clusters in the **O** and **Z** sections of the list.

--- a/Contributing.md
+++ b/Contributing.md
@@ -2,7 +2,7 @@
 
 First and foremost, thanks for the help, I appreciate all of the contributions, and the awesome-zsh-plugins list wouldn't be nearly as complete without them. You may add to the list by submitting a pull request or adding a link in an issue.
 
-I want to be clear that real, useful PRs are welcome. But if you came here just to make a junk PR because you watched that idiot CodeWithHarry's youtube video, _I will report it to DigitalOcean, you will be disqualified from Hacktoberfest and you won't get the free stuff you're trying for._
+I want to be clear that real, useful PRs are always welcome. _But_ if you came here just to make a PR because you watched that idiot CodeWithHarry's youtube video, _I will report it to DigitalOcean_, you will be disqualified from Hacktoberfest and you won't get the free stuff you're trying for._
 
 ## Entry Guidelines
 
@@ -10,20 +10,32 @@ I want to be clear that real, useful PRs are welcome. But if you came here just 
 
 * Please make sure all new framework, plugin, themes or completions entries have a license file. Some users are particular about the code they use and want to be sure they are compliant with licensing, so please make sure it's easy for them to determine what the license is. I am aware that there are existing entries without licenses, they were added before I instituted the license policy.
 
+* Please make sure new entries have a readme. While obviously it's good to read the source code for things we're adding to our environment, it's even better if users can get an overall idea of what a plugin does so they know if it is even potentially useful to them first.
+
 * Descriptions should be clear, concise, and non-promotional.
+
 * The list is split into sections for frameworks, plugins, themes and completions, please add your entries to the appropriate section(s). If an entry is a plugin that provides both plugin functionality and tab completions, add it to the plugins section. If an entry is a plugin that provides both plugin functionality and a theme, please add it to the theme section. The completions section is meant for projects that only provide extra tab completions.
+
 * Descriptions should follow the link, on the same line, with capitalization consistent with the other entries in the section.
+
 * Each entry should be a single line that ends in a period. This makes keeping the sections sorted easier. We let GitHub's markdown formatter handle adding any required line breaks rather than embedding breaks in the entries ourselves, this also allows us to work with any browser window width.
+
 * For consistency, please use all caps for ZSH in all entry descriptions.
+
 * Each entry should be limited to one link, and that link should be the first part of the line. It is ok to submit more than one entry in a PR.
+
 * Please make sure all framework, plugin, themes or completions list entries are sorted *alphabetically*.
+
 * The link should be named the name of the package or project.
+
 * Your PR should pass the CircleCI checks. If the checks show an error that you didn't add (a previous plugin entry has gone 404, for example) you don't _have_ to fix those errors, though I'll certainly appreciate the help if you do, or if you create an issue documenting the problem so I can fix it.
 
 ### Themes
 
 * If you're submitting a theme, please make sure that the theme repo has a screen shot so that list users can tell what it looks like before installing it.
-* It is fine to have multiple new entries in a single PR.
+
+* It is fine to have multiple new entries in a single PR. Just make sure they all have readmes and licenses, and screenshots for theme entries.
+
 * No need to squash commits. It is fine to have multiple commits in a PR.
 
 ## To remove an entry:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

- Call out need for readmes in PR template
- Update contributing guidelins

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove/update a link to a framework
- [ ] Add/remove/update a link to a plugin
- [ ] Add/remove/update a link to a tab completion
- [ ] Add/remove/update a link to a theme
- [x] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply.

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [x] All new and existing tests passed.
- [ ] Any added completions have a license file in their repository.
- [ ] Any added frameworks have a license file in their repository.
- [ ] Any added plugins have a license file in their repository.
- [ ] Any added themes have a screen shot and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-**, **zsh-plugin** and/or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name by preventing big clusters in the **O** and **Z** sections of the list.
