### PR TITLE
Relocate miniplug to sr.ht

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find some interesting performance timing comparisons of various framewor
 
 **fresh** is a tool to source shell configuration (aliases, functions, etc) from others into your own configuration files. We also support files such as ackrc and gitconfig. Think of it as Bundler for your dot files.
 
-### [miniplug](https://github.com/YerinAlexey/miniplug)
+### [miniplug](https://sr.ht/~yerinalexey/miniplug)
 
 **miniplug** is a minimalistic plugin manager for ZSH.
 


### PR DESCRIPTION
# Description

Miniplug's canonical source code repository is on sourcehut: https://sr.ht/~yerinalexey/miniplug. The Github repository right now works as a mirror and may be deleted in the future.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [x] Add/remove/update a link to a framework
- [ ] Add/remove/update a link to a plugin
- [ ] Add/remove/update a link to a tab completion
- [ ] Add/remove/update a link to a theme
- [ ] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply.

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines and are in the appropriate (plugins, themes or completions) section, and in alphabetical order in their section.
- [ ] All new and existing tests passed.
- [x] Any added frameworks have a readme and a license file in their repository.
