### PR TITLE
style: ✅ Update codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,15 +1,16 @@
 ---
-engines:
+version: "2"
+plugins:
   pep8:
     enabled: true
   duplication:
     enabled: true
     config:
       languages:
-      - "python"
+        - "python"
   fixme:
     enabled: true
-    exclude_paths:
+    exclude_patterns:
       - config/engines.yml
   markdownlint:
     enabled: true
@@ -26,15 +27,12 @@ engines:
         enabled: false
   shellcheck:
     enabled: true
-ratings:
-  paths:
-  - "**.md"
-exclude_paths:
-  - .bundle/
-  - benchmarks/**/*
-  - node_modules/**/*
-  - bin/**/*
-  - include/**/*
-  - lib/**/*
-  - License.md
-  - spec/**/*
+    exclude_patterns:
+      - .bundle/
+      - benchmarks/**/*
+      - node_modules/**/*
+      - bin/**/*
+      - include/**/*
+      - lib/**/*
+      - License.md
+      - spec/**/*

--- a/Writing_Plugins_and_Themes.md
+++ b/Writing_Plugins_and_Themes.md
@@ -17,8 +17,9 @@ Here are some suggestions to make installing and using your plugin/theme as simp
 7. If your plugin adds any of its subdirectories to the user's `fpath`, make sure those subdirectories only contain function definition files. This allows for frameworks to correctly [zcompile all functions](http://zsh.sourceforge.net/Doc/Release/Functions.html#Autoloading-Functions). Please don't make your plugin add its root directory to the `fpath` - this will cause problems with `zcompile`.
 
 8. Leave ZSH settings alone.
-  - If you're using `setopt` to override the user's existing settings, you _will_ break someone's workflow. If you feel you absolutely must tweak `setopt` settings, make sure there's an easy way to disable your overrides - consider looking for a file named `~/.YOURPLUGIN_disable_SETTINGSNAME`.
-  -  If you're touching the magic ZSH settings variables like `HISTSIZE`, _only do it if the variable is unset_. Wrap it in a `if [[ -z "$VARNAME" ]]; then` block so you don't step on a user's existing settings.
+
+   - If you're using `setopt` to override the user's existing settings, you _will_ break someone's workflow. If you feel you absolutely must tweak `setopt` settings, make sure there's an easy way to disable your overrides - consider looking for a file named `~/.YOURPLUGIN_disable_SETTINGSNAME`.
+   - If you're touching the magic ZSH settings variables like `HISTSIZE`, _only do it if the variable is unset_. Wrap it in a `if [[ -z "$VARNAME" ]]; then` block so you don't step on a user's existing settings.
 
 9. Don't forget to add a license. A lot of people won't use anything that doesn't have a license. [choosealicense.com](https://choosealicense.com) is a good tool to help you pick one if you don't already have something specific in mind.
 


### PR DESCRIPTION
# Fix:

- `exclude_paths` has been deprecated,
- `engines` has been deprecated,
- `exclude_paths` has been deprecated,
- `ratings` have been deprecated.

Notes: linted with new configuration (1 file): Writing_Plugins_and_Themes.md

### Syslog

```shell
➜  awesome-zsh-plugins git:(codeclimate) ✗ codeclimate validate-config
No errors or warnings found in .codeclimate.yml.
```
```shell
➜  awesome-zsh-plugins git:(codeclimate) ✗ codeclimate analyze        
Starting analysis
Running structure: Done!
Running duplication: Done!
Running pep8: Done!
Running fixme: Done!
Running markdownlint: Done!
Running shellcheck: Done!
```
```shell
== README.md (4 issues) ==
105: Lists should be surrounded by blank lines [markdownlint]
2116: Multiple headers with the same content [markdownlint]
2144: Multiple headers with the same content [markdownlint]
2148: Multiple headers with the same content [markdownlint]
```
```shell
== zsh-plugin-assessor/zsh-plugin-assessor (4 issues) ==
96: "Couldn't parse this test expression. [shellcheck]"
96: "Expected another argument for this operator. [shellcheck]"
96: "'(' is invalid here. Did you forget to escape it? [shellcheck]"
96: "Fix any mentioned problems and try again. [shellcheck]"

Analysis complete! Found 8 issues.
```

### References

- https://docs.codeclimate.com/docs/list-of-engines
- https://docs.codeclimate.com/docs/engine-channels
- https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md

### Summary

All issues and changes are listed above. If no changes are required, will address the issues above as chosen below or instructed otherwise.

- [ ] New pull request
- [ ] Current pull request

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A link to an external resource like a blog post
- [ ] Add/remove/update a link to a framework
- [ ] Add/remove/update a link to a plugin
- [ ] Add/remove/update a link to a tab completion
- [ ] Add/remove/update a link to a theme
- [x] Text cleanups/typo fixes

# Copyright Assignment

- [x] This document is covered by the [BSD License](https://github.com/unixorn/awesome-zsh-plugins/blob/master/LICENSE), and I agree to contribute this PR under the terms of the license. This is for the list submission, not for the project(s) you're adding, I don't care what license the plugins have as long as they have something.

# Checklist:

<!---
Go over all the following points, and put an `x` in all the boxes that apply.

You only need to check the box for completions/plugins/themes if you added something in those categories
-->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/awesome-zsh-plugins/blob/main/Contributing.md) document.
- [x] All new and existing tests passed.
- [ ] I have confirmed that the link(s) in my PR is valid.
- [x] I have signed off my commits. You can use `git commit --amend --no-edit --signoff` to amend an existing commit, and you can find more details about signing off commits on the DCO GitHub action page [here](https://probot.github.io/apps/dco/)
- [ ] My entries are single lines and are in the appropriate (plugins, themes, or completions) section, and in alphabetical order in their section.
- [ ] Any added completions have a readme and a license file in their repository.
- [ ] Any added frameworks have a readme and a license file in their repository.
- [ ] Any added plugins have a readme and a license file in their repository.
- [ ] Any added themes have a screenshot, a readme, and a license file in their repository.
- [ ] I have stripped leading and trailing **zsh-**, **zsh-plugin** and/or **oh-my-zsh-** substrings from the link name. This makes it easier to find plugins/themes/completions by name by preventing big clusters in the **O** and **Z** sections of the list.