### PR TITLE
Add zsh-vi-man plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1794,6 +1794,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [zsh-in-docker](https://github.com/deluan/zsh-in-docker) - Automates ZSH + [oh-my-zsh](https://ohmyz.sh/) installation into development containers. Works with Alpine, Ubuntu, Debian, CentOS or Amazon Linux.
 - [zsh-not-vim](https://github.com/redxtech/zsh-not-vim) - Provides a function that automatically shames the user for forgetting they weren't in `vim`.
 - [zsh-select](https://github.com/z-shell/zsh-select) - Displays a selection list. It is similar to `selecta`, but uses the curses library to do display, and when compared to [fzf](https://github.com/junegunn/fzf), the main difference is approximate matching instead of fuzzy matching.
+- [zsh-vi-man](https://github.com/TunaCuma/zsh-vi-man) - Smart man page lookup for zsh vi mode. Press `Shift-K` on any command or option to instantly open its man page with smart detection for subcommands, option jumping, combined options, and pipe support.
 - [zsh-watch](https://github.com/Thearas/zsh-watch) - Simple `watch` that supports alias and completion.
 - [zsh-z (agkozak)](https://github.com/agkozak/zsh-z) - Jump quickly to directories that you have visited "frecently." A native ZSH port of `z.sh` - without `awk`, `sed`, `sort`, or `date`.
 - [zsh-z (ptavares)](https://github.com/ptavares/zsh-z) - Installs and loads [z](https://github.com/rupa/z.git).


### PR DESCRIPTION
## Description

Adds [zsh-vi-man](https://github.com/TunaCuma/zsh-vi-man) - a smart man page lookup plugin for zsh vi mode.

<img width="900" height="500" alt="image" src="https://raw.githubusercontent.com/TunaCuma/zsh-vi-man/main/demo.gif" />

## Features

- **Smart detection**: Automatically finds the right man page for subcommands (e.g., `git commit` → `man git-commit`)
- **Option jumping**: Opens man page directly at the option definition
- **Combined options**: Works with combined short options (e.g., `rm -rf`)
- **Pipe support**: Detects correct command in pipelines
- **Value extraction**: Handles options with values

## Usage

Press `Shift-K` on any command or option to instantly open its man page.

## Repository

https://github.com/TunaCuma/zsh-vi-man