### PR TITLE
Add flow-cli - ADHD workflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [fishysave](https://github.com/dariogliendo/fishysave.zsh) - Save and update functions and aliases directly from your terminal session.
 - [fixnumpad-osx](https://github.com/zackintosh/fixnumpad-osx.plugin.zsh) - Enables numpad keys of Apple keyboards to be recognized in ZSH.
 - [flow-plugin](https://github.com/sandstorm/oh-my-zsh-flow-plugin) - This plugin makes the `flow` command available inside every subdirectory of the TYPO3 Flow distribution.
+- [flow-cli](https://github.com/Data-Wise/flow-cli) - ADHD-friendly ZSH workflow tools. Start working in 10 seconds with `work`, track wins for dopamine with `win`, stay oriented with `dash`. Includes smart dispatchers for git, R, Quarto, and Claude Code.
 - [flutter-zsh-shortcuts](https://github.com/dizzpy/flutter-zsh-shortcuts) - Adds clean aliases for flutter commands.
 - [fnm (dominik-schwabe)](https://github.com/dominik-schwabe/zsh-fnm) - Installs and loads the [Fast Node Manager (fnm)](https://github.com/Schniz/fnm) if it is missing.
 - [fnm (wintermi)](https://github.com/wintermi/zsh-fnm) - Helper plugin for the fast and simple Node.js version manager [fnm](https://github.com/Schniz/fnm).


### PR DESCRIPTION
## Description
Adds [flow-cli](https://github.com/Data-Wise/flow-cli) to the plugins list.

**flow-cli** is a pure ZSH plugin designed for ADHD brains:
- Start working in 10 seconds with `work`
- Track wins for dopamine with `win`
- Stay oriented with `dash` dashboard
- Smart dispatchers for git, R, Quarto, Claude Code

## Checklist
- [x] Alphabetically sorted in the correct section
- [x] Link works and points to the project
- [x] Description follows the format of other entries
- [x] Signed-off-by included for DCO