### PR TITLE
Add arc-prompt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [apt](https://github.com/GeoLMg/apt-zsh-plugin) - For distros with `apt` package manager. Offers to install missing programs for you.
 - [arc-search](https://github.com/michaelsousajr/zsh-arc-search) - Enables quick searches using Arc browser directly from your terminal. Features URL encoding for search terms.
 - [arc](https://github.com/anton-rudeshko/zsh-arc) - Adds aliases for Yandex version control system.
+- [arc-prompt](https://github.com/dkryaklin/arc-zsh-plugin) - Arc VCS prompt integration with branch display, status caching, operation mode detection, agnoster theme support, and aliases.
 - [archlinux (fourdim)](https://github.com/fourdim/zsh-archlinux) - Defines helper functions for `pacman` on Arch Linux.
 - [archlinux (junker)](https://github.com/Junker/zsh-archlinux) - Based on the oh-my-zsh [archlinux](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/archlinux) plugin. Defines helper functions and aliases.
 - [arduino](https://github.com/raghur/zsh-arduino) - Adds scripts to build, upload and monitor arduino sketches from a command line. Requires [`jq`](https://stedolan.github.io/jq/).


### PR DESCRIPTION
Adds [arc-prompt](https://github.com/dkryaklin/arc-zsh-plugin) — Arc VCS prompt integration with branch display, status caching, operation mode detection, agnoster theme support, and aliases.

- Has a LICENSE (MIT)
- Has a README
- Entry is alphabetically placed in the Plugins section