### PR TITLE
Add zsh-nvm-x plugin to README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [nvm-lazy](https://github.com/davidparsson/zsh-nvm-lazy) - Plugin for lazy loading of oh-my-zsh's **nvm*- plugin. It supports lazy-loading `nvm` for more than one binary/entrypoint, with the defaults being `nvm`, `node` and `npm`.
 - [nvm-pnpm-auto-switch](https://github.com/spencerbeggs/zsh-nvm-pnpm-auto-switch) - Automatically switches Node.js versions (using `nvm`) and manages pnpm package manager versions (using `corepack`) when changing directories.
 - [nvm](https://github.com/lukechilds/zsh-nvm) - ZSH plugin for installing, updating and loading `nvm`.
+- [zsh-nvm-x](https://github.com/seebeen/zsh-nvm-x) - ZSH plugin for managing `nvm` with extended helpers and improved workflow.
 - [oath](https://github.com/alexdesousa/oath) - Manages 2FA authentication 6 digit tokens. It was highly inspired by this article about [using oathtool for 2 step verification](https://www.cyberciti.biz/faq/use-oathtool-linux-command-line-for-2-step-verification-2fa/).
 - [oh-my-gpt](https://github.com/vicotrbb/oh-my-gpt) - Provides an easy-to-use interface for interacting with OpenAI's GPT models directly from your terminal. It allows you to send queries, analyze files, and get AI-powered assistance for various tasks.
 - [oh-my-matrix](https://github.com/amstrad/oh-my-matrix) - Turn your terminal into the matrix.


### PR DESCRIPTION
## Summary
- Add `zsh-nvm-x` plugin entry to `README.md` in the plugin list.
- Plugin added under the correct alphabetical area between `nvm` and `oath`.
- No code/runtime changes; documentation/listing update only.

## Type of change
- [x] Documentation update
- [x] New plugin submission
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] I have read the contribution guidelines.
- [x] I added only one plugin entry.
- [x] The plugin repository is publicly accessible.
- [x] The plugin has a README with usage/install information.
- [x] The plugin includes a license file.
- [x] The entry is placed in alphabetical order.
- [x] The link points to the correct repository.
- [x] This PR only changes `README.md`.
- [x] I signed off my commit(s) (`git commit --signoff`).

## Notes
- Current visible link text in README is `zsh-nvm-x`.