### PR TITLE
Add Lacy Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [kubectx (unixorn)](https://github.com/unixorn/kubectx-zshplugin) - Automatically installs [kubectx](https://github.com/ahmetb/kubectx) and `kubens`.
 - [kubernetes](https://github.com/Dbz/zsh-kubernetes) - Add [kubernetes](https://kubernetes.io) helper functions and aliases.
 - [lacrimae](https://github.com/caIamity/lacrimae) - Prints a line from a collection of chants.
+- [lacy](https://github.com/lacymorrow/lacy) - Detects natural language vs shell commands and routes accordingly. Commands execute normally, questions go to your AI agent (Claude Code, Gemini, OpenCode, Codex). Real-time color indicator and first-word syntax highlighting update on every keystroke. Also supports Bash 4+.
 - [lando (joshuabedford)](https://github.com/JoshuaBedford/lando-zsh) - A collection of alias functions to enable the use of the CLIs within [Lando](https://docs.lando.dev) without having to type lando to access them.
 - [lando (mannuel)](https://github.com/mannuel/lando-alias-zsh) - Adds aliases for various [Lando](https://docs.lando.dev/basics/usage.html#default-commands/) commands.
 - [laradock-workspace](https://github.com/rluders/laradock-workspace-zsh) - Provides an interface to [Laradock](http://laradock.io/)'s workspace.


### PR DESCRIPTION
Add [Lacy Shell](https://github.com/lacymorrow/lacy) to the Plugins section.

Lacy is a ZSH/Bash plugin that detects natural language vs shell commands and routes accordingly. Commands execute normally in your shell, questions go to your AI agent (Claude Code, Gemini CLI, OpenCode, Codex, or Lash). Features a real-time color indicator and first-word syntax highlighting that updates on every keystroke.

- Has a [README](https://github.com/lacymorrow/lacy#readme)
- Has an [MIT license](https://github.com/lacymorrow/lacy/blob/main/LICENSE)
- Entry added in alphabetical order in the Plugins section