### PR TITLE
Add zsh-paste-guard plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1418,6 +1418,7 @@ Here are a few good sources for Nerd Fonts and Powerline-compatible fonts:
 - [packer](https://github.com/BreakingPitt/zsh-packer) - Adds aliases and auto-completes for Hashicorp [packer](https://www.packer.io/).
 - [pantheon-terminal-notify](https://github.com/deyvisonrocha/pantheon-terminal-notify-zsh-plugin) - Background notifications for long running commands. Supports Elementary OS Freya.
 - [passwordless-history](https://github.com/jgogstad/passwordless-history) - Keeps passwords from entering your command line history.
+- [paste-guard](https://github.com/stefanoamorelli/zsh-paste-guard) - Detects pasted commands and requires a confirmation phrase before execution to prevent clipboard injection attacks (MITRE ATT&CK T1204.004). Reads confirmation from `/dev/tty` so attackers cannot embed the confirmation in the payload.
 - [path-ethic](https://github.com/sha1n/path-ethic) - Helps manage your `$PATH` quickly and easily. Doesn't touch your existing `.zshrc`, `.zprofile`, but adds on top of your existing environment instead.
 - [pctl](https://github.com/ytet5uy4/pctl) - Toggle the environment variables for proxying.
 - [peco-history](https://github.com/jimeh/zsh-peco-history) - Search shell history with Peco when pressing `ctrl+R`.


### PR DESCRIPTION
## Description

Add [zsh-paste-guard](https://github.com/stefanoamorelli/zsh-paste-guard) to the Plugins section.

**zsh-paste-guard** is a ZSH plugin that detects pasted commands and requires a typed confirmation phrase before execution, preventing clipboard injection attacks ([MITRE ATT&CK T1204.004](https://attack.mitre.org/techniques/T1204/004/)). Confirmation is read directly from `/dev/tty` so attackers cannot embed the confirmation phrase in the pasted payload.

### Key features
- Uses bracketed paste mode to detect pasted input
- Requires typed confirmation before executing pasted commands
- Zero friction for manually typed commands
- No external dependencies — pure ZSH builtins
- Compatible with Oh My Zsh, zinit, antigen, and zplug

### Why this is useful
Clipboard injection ("ClickFix") attacks have seen a 517% surge between H2 2024 and H1 2025. This plugin provides a simple, zero-dependency defense at the shell level.