### PR TITLE
Add zsh-startcache plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1659,6 +1659,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [sshpky](https://github.com/jeffzhangc/sshpky_zsh_plugin) - Auto updates git-repositories in the `$ZSH_CUSTOM` folder.
 - [sshukh](https://github.com/anatolykopyl/sshukh-zsh-plugin) - Will update your `known_hosts` file when you `ssh` into a server.
 - [startify](https://github.com/NorthIsMirror/zsh-startify) - Shows recently used `vim` files, shell-util files, active `tmux` sessions, recently-run `git` commands and more.
+- [startcache](https://github.com/rndjams/zsh-startcache) - Speeds up shell startup by caching the output of slow `eval "$(tool init)"` commands and replacing `compinit`'s fpath-string invalidation with time-based staleness. Saves 110ms–1180ms per shell depending on configuration.
 - [startup-timer](https://github.com/paulmelnikow/zsh-startup-timer) - Print the time it takes for the shell to start up.
 - [stashy](https://github.com/MisterRios/stashy) - Plugin that simplifies using `git stash`.
 - [statify](https://github.com/vladmrnv/statify) - Plugin that does basic statistical analysis.


### PR DESCRIPTION
Adds [zsh-startcache](https://github.com/rndjams/zsh-startcache) to the plugins list.

**What it does:**
- `_startcache_eval` — caches output of slow `eval "$(tool init)"` commands (brew, mise, direnv, starship). Sources from file on subsequent shells instead of spawning subprocesses.
- `_startcache_compinit` — replaces compinit's fpath-string comparison with time-based staleness (default 24h). Prevents unnecessary full rebuilds caused by fpath ordering drift across sessions.

**Benchmarks (M1 Pro, zsh 5.9, OMZ 13 plugins):**
- Eval caching: 169ms → 59ms (2.9x, saves 110ms)
- Compinit caching: 1083ms → 12ms (89x when rebuild avoided)
- Combined worst case: 1252ms → 71ms (17.6x)

Works with any plugin manager (zinit, antidote, sheldon) and as an OMZ custom plugin.