### PR TITLE
Add colored-man-pages-plus to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [color-logging](https://github.com/p1r473/zsh-color-logging) - provides a really easy to use logging library with notifications for pushbullet and pushover, colorizes tools like `cat` and `ls` and provides a color library.
 - [colored-man-pages-mod](https://github.com/zuxfoucault/colored-man-pages_mod) - Forked from [ohmyzsh/ohmyzsh/plugins/colored-man-pages](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/colored-man-pages/colored-man-pages.plugin.zsh). Colorizes `man` output.
 - [colored-man-pages](https://github.com/ael-code/zsh-colored-man-pages) - Colorize `man` pages.
+- [colored-man-pages-plus](https://github.com/diverdale/colored-man-pages-plus) - Semantically colorizes `man` pages by role with curated truecolor themes, OSC-8 links, and automatic light/dark detection.
 - [colorize-functions](https://github.com/Freed-Wu/zsh-colorize-functions) - Colorizes functions for ZSH.
 - [colorize](https://github.com/zpm-zsh/colorize) - Colorize the output of various programs.
 - [colorls](https://github.com/Kallahan23/zsh-colorls) - Defines a few helpful shortcuts to some colorls functions.


### PR DESCRIPTION
Adds [colored-man-pages-plus](https://github.com/diverdale/colored-man-pages-plus) to the Plugins section.

It's a semantic, themeable `man` page colorizer for ZSH — a drop-in upgrade to oh-my-zsh's `colored-man-pages`. Instead of tinting by text attribute, it colors by role (headers, commands, flags, arguments, paths, literals) with curated truecolor themes (Dracula, Catppuccin, Gruvbox, Tokyo Night, light, ansi), OSC-8 links, automatic light/dark detection, and a `man-theme` switcher.

Checklist per Contributing.md:
- [x] Has a README
- [x] Has a LICENSE (MIT)
- [x] Single line, ends in a period, non-promotional
- [x] Added in alphabetical order in the Plugins section
- [x] "ZSH" capitalized; link text is the project name