### PR TITLE
Add ccline - AI-powered command_not_found handler for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [caper-bush](https://github.com/kobylinski/caper-bush) - Enhances Git's tab autocomplete by using AI to generate concise, context-aware summaries of staged changes for thoughtful commit messages. Requires and OpenAI key, `jq` and `yq`.
 - [careful_rm](https://github.com/MikeDacre/careful_rm) - A wrapper for `rm` that adds trash/recycling and useful warnings.
 - [case](https://github.com/rtuin/zsh-case) - A ZSH plugin that adds two aliases `tolower` and `toupper` to switch output case.
+- [ccline](https://github.com/jianshuo/ccline) - Type a thought at your zsh prompt — no command, no prefix — and get an answer from Claude or Codex. If the answer contains shell commands, confirm once and run them.
 - [ccusage](https://github.com/hydai/zsh-ccusage) - Displays real-time AI usage costs from the `ccusage` CLI tool directly in your terminal prompt.
 - [cd-gitroot](https://github.com/mollifier/cd-gitroot) - A ZSH plugin to `cd` to the `git` repository root directory.
 - [cd-ls](https://github.com/zshzoo/cd-ls) - Automatically `ls` after `cd`.


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — type a thought directly at your zsh prompt (no command, no prefix) and get an answer from Claude or Codex. If the answer contains runnable shell commands, an arrow-key menu lets you confirm and run them.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   find . -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

It hijacks zsh's `command_not_found_handler`. One-word inputs (typos) are passed through normally; two-or-more-word inputs are sent to the LLM.

## Requirements

- zsh
- `claude` CLI or `codex` CLI (auto-detected, claude preferred)

## Checklist

- [x] Repo is public and has a README
- [x] Plugin works with zsh
- [x] No malware or suspicious code
- [x] Link follows the existing format