### PR TITLE
Add better-chmod plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [battery_state](https://github.com/Jactry/zsh_battery_state) - Show battery state in right-prompt.
 - [bd](https://github.com/Tarrasch/zsh-bd) - Jump back to a specific directory, without doing `cd ../../..`.
 - [bepoptimist](https://github.com/sheoak/zsh-bepoptimist/) Remaps vi-mode for the French [bépo](http://bepo.fr/wiki/Accueil) keyboard.
+- [better-chmod](https://github.com/Balzabu/zsh-better-chmod) - Adds a `bchmod` command (and an optional `chmod` replacement) that accepts symbolic and octal permission formats with input validation and colored output.
 - [bitbucket-git-helpers](https://github.com/unixorn/bitbucket-git-helpers.plugin.zsh) - Adds helper scripts to allow you to create bitbucket PRs or open a directory in the current branch.
 - [bitwarden (casonadams)](https://github.com/casonadams/bitwarden-cli) - A [Bitwarden](https://bitwarden.com/download/) CLI fuzzy finder using [fzf](https://github.com/junegunn/fzf). Requires [jq](https://stedolan.github.io/jq/).
 - [bitwarden (game4move78)](https://github.com/Game4Move78/zsh-bitwarden) - Adds functions to manage [bitwarden](https://bitwarden.com/) sessions.


### PR DESCRIPTION
# Description

Adds [better-chmod](https://github.com/Balzabu/zsh-better-chmod) to the Plugins section. It provides a `bchmod` command (with an optional `chmod` replacement) that accepts symbolic (`-rwxr-xr--`) and octal (`755`) permissions, with input validation and colored output. The repository has a README and an MIT license, and the plugin file follows the ZSH Plugin Standard. The entry is a single line, placed alphabetically between `bepoptimist` and `bitbucket-git-helpers`.

## Type of changes

- [x] Add/remove/update a link to a plugin

## Copyright Assignment

- [x] This document is covered by the BSD License, and I agree to contribute this PR under the terms of the license.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] All new and existing tests passed.
- [x] I have confirmed that the link(s) in my PR is valid.
- [x] I have signed off my commits.
- [x] My entries are single lines and are in the appropriate section, and in alphabetical order in their section.
- [x] The plugin has a plugin file (`zsh-better-chmod.plugin.zsh`) that conforms to the ZSH Plugin Standard.
- [x] The added plugin has a readme and a license file in its repository.
- [x] I have stripped the leading `zsh-` substring from the link's displayed name (shown as `better-chmod`).
