### PR TITLE
Add pnpm-completions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1545,6 +1545,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [pnpm (leizhenpeng)](https://github.com/Leizhenpeng/zsh-plugin-pnpm) - Adds useful aliases for common [pnpm](https://pnpm.io/) commands.
 - [pnpm (mat2ja)](https://github.com/mat2ja/pnpm.plugin.zsh) - Better [pnpm](https://pnpm.io/) aliases.
 - [pnpm (ntnyq)](https://github.com/ntnyq/omz-plugin-pnpm) - Adds useful aliases for common [pnpm](https://pnpm.io/) commands.
+- [pnpm-completions](https://github.com/michakfromparis/zsh-pnpm-completions) - Tab completions for `pnpm` with `package.json` script completion, live npm registry search, workspace support, and optional command aliases.
 - [pnpm-pick](https://github.com/rschaufler/zsh-pnpm-pick) - Fuzzy-pick a script from any package in a [pnpm](https://pnpm.io/) workspace and load the command into your prompt — editable, in your history, and visible in your terminal title.
 - [poetry (darvid)](https://github.com/darvid/zsh-poetry) - Automatically activates and deactivates [Poetry](https://poetry.eustace.io/)-created python virtualenvs.
 - [poetry (murku)](https://github.com/murku/omz_poetry_plugin) - Adds aliases for frequently used [Poetry](https://poetry.eustace.io/) commands


### PR DESCRIPTION
## Summary

Adds [zsh-pnpm-completions](https://github.com/michakfromparis/zsh-pnpm-completions) to the Plugins section.

The plugin provides tab completions for `pnpm`, including `package.json` script completion, live npm registry search, workspace-aware completions, and optional command aliases. It has an MIT license and README.

## Checklist

- [x] Entry added in alphabetical order in the Plugins section
- [x] Single-line description ending with a period
- [x] Project has a license (MIT) and README