### PR TITLE
Add create-ai-memory to the plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [cowsay](https://github.com/phucisstupid/cowsay.zsh) - Displays a joke with `cowsay` every time you open a terminal.
 - [crash](https://github.com/molovo/crash) - Adds proper error handling, exceptions and try/catch for ZSH.
 - [crayon-syntax](https://github.com/gsemet/crayon-syntax-zsh) - ZSH syntax highlighting for the Crayon Plugin for Wordpress.
+- [create-ai-memory](https://github.com/rambaarde/create-ai-memory) - Persistent, agent-agnostic session memory for AI coding CLIs; loads a Markdown vault of profile, project, and session context into ZSH launchers for Claude Code, Codex, Gemini, Cursor, and opencode.
 - [cros-auto-notify](https://github.com/D3STY/cros-auto-notify-zsh) - Automatically sends out a notification when a long running task has completed. Works with macOS and linux (if `hterm-notify` is installed).
 - [crystal](https://github.com/veelenga/crystal-zsh) - A plugin for [Crystal](https://github.com/crystal-lang/crystal).
 - [ctrl-z](https://github.com/Zile995/zsh-ctrl-z) - Enhances the default CTRL+Z behavior using [fzf](https://github.com/junegunn/fzf). It allows you to visually browse, resume, or terminate suspended background jobs directly from your terminal prompt.


### PR DESCRIPTION
Adds [create-ai-memory](https://github.com/rambaarde/create-ai-memory), a ZSH plugin that gives AI coding CLIs persistent session memory.

- Provides ZSH functions (`claude-start`, `codex-start`, `gemini-start`, `cursor-start`, `opencode-start`, `ai-note`) loaded via `create-ai-memory.plugin.zsh`.
- Installable with zinit/antidote/oh-my-zsh, or `npm create ai-memory@latest`.
- Has a README and an MIT LICENSE.
- Entry added as a single line in the plugins section, in alphabetical order, ending in a period, with ZSH capitalized.