### PR TITLE
Add git-persona plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,7 @@ If you're looking for a new font to use, check out [www.codingfont.com](https://
 - [git-it-on](https://github.com/peterhurford/git-it-on.zsh) - Adds ability to open a folder in your current branch on GitHub.
 - [git-lfs](https://github.com/nekofar/zsh-git-lfs) - Adds short aliases for the `git-lfs` commands.
 - [git-patch](https://github.com/marvinroman/oh-my-zsh-git-patch-plugin) - Adds custom functions and aliases to the oh-my-zsh `git` plugin.
+- [git-persona](https://github.com/asifshirazi/zsh-git-persona) - Switches `git` commit identity, SSH key and `gh` CLI account together for multiple GitHub accounts.
 - [git-plugin (dark-kitt)](https://github.com/dark-kitt/zsh-git-plugin) - `git` integration that displays the current directory and `git` branch.
 - [git-plugin (rcruzper)](https://github.com/rcruzper/zsh-git-plugin) - Adds some functions for `git`.
 - [git-plugin-cheatsheet](https://github.com/rhorno/oh-my-zsh-git-plugin-cheatsheet) - Displays the aliases and functions available from the `git` oh-my-zsh plugin.


### PR DESCRIPTION
Adds [git-persona](https://github.com/asifshirazi/zsh-git-persona) to the Plugins section.

It switches your `git` commit identity, SSH key and `gh` CLI account together, so a commit cannot be authored by one GitHub account and pushed with another's credentials.

- MIT licensed
- Has a readme with install instructions and a screenshot
- Single line entry, added in alphabetical order between `git-patch` and `git-plugin (dark-kitt)`
- Commit is signed off for DCO